### PR TITLE
Fix server crashing on launch

### DIFF
--- a/src/main/java/io/github/simplycmd/camping/Main.java
+++ b/src/main/java/io/github/simplycmd/camping/Main.java
@@ -152,7 +152,6 @@ public class Main implements ModInitializer, ClientModInitializer {
 		Registry.register(Registry.SOUND_EVENT, WINDY2_ID, WINDY2_EVENT);
 		Registry.register(Registry.SOUND_EVENT, BIRDS1_ID, BIRDS1_EVENT);
 		Registry.register(Registry.SOUND_EVENT, BIRDS2_ID, BIRDS2_EVENT);
-		AmbientSoundHandler.start();
 
 		// --------------------------------------------------------------------
 		// Register Entities
@@ -164,7 +163,6 @@ public class Main implements ModInitializer, ClientModInitializer {
 		Registry.register(Registry.BLOCK, new Identifier(MOD_ID, "pine_log"), PINE_LOG);
 		Registry.register(Registry.BLOCK, new Identifier(MOD_ID, "hot_spring_water"), HOT_SPRING_WATER);
 		Registry.register(Registry.BLOCK, new Identifier(MOD_ID, "sleeping_bag"), SLEEPING_BAG);
-		ColorProviderRegistry.BLOCK.register((state, view, pos, tintIndex) -> state.get(SleepingBagBlock.COLOR).getFireworkColor(), SLEEPING_BAG);
 
 		// --------------------------------------------------------------------
 		// Register Items
@@ -228,19 +226,33 @@ public class Main implements ModInitializer, ClientModInitializer {
 	}
 
 	@Environment(EnvType.CLIENT)
-	public static final EntityModelLayer MODEL_BROWN_BEAR_LAYER = new EntityModelLayer(new Identifier(Main.MOD_ID, "brown_bear"), "main");
+	public static EntityModelLayer MODEL_BROWN_BEAR_LAYER;
 	@Environment(EnvType.CLIENT)
-	public static final EntityModelLayer MODEL_BASS_LAYER = new EntityModelLayer(new Identifier(Main.MOD_ID, "bass"), "main");
+	public static EntityModelLayer MODEL_BASS_LAYER;
 
 	@Environment(EnvType.CLIENT)
 	@Override
 	public void onInitializeClient() {
+		// --------------------------------------------------------------------
+		// Start client-side sounds
+		AmbientSoundHandler.start();
+
+		// --------------------------------------------------------------------
+		// Register client-side block colors for maps
+		ColorProviderRegistry.BLOCK.register((state, view, pos, tintIndex) -> state.get(SleepingBagBlock.COLOR).getFireworkColor(), SLEEPING_BAG);
+
+		// --------------------------------------------------------------------
+		// Register renderers for entities
+		MODEL_BROWN_BEAR_LAYER = new EntityModelLayer(new Identifier(Main.MOD_ID, "brown_bear"), "main");
 		EntityRendererRegistry.INSTANCE.register(Main.BROWN_BEAR, BrownBearEntityRenderer::new);
 		EntityModelLayerRegistry.registerModelLayer(MODEL_BROWN_BEAR_LAYER, BrownBearEntityModel::getTexturedModelData);
 
+		MODEL_BASS_LAYER = new EntityModelLayer(new Identifier(Main.MOD_ID, "bass"), "main");
 		EntityRendererRegistry.INSTANCE.register(Main.BASS, BassEntityRenderer::new);
 		EntityModelLayerRegistry.registerModelLayer(MODEL_BASS_LAYER, BassEntityModel::getTexturedModelData);
 
+		// --------------------------------------------------------------------
+		// Register renderers for blocks
 		BlockRenderLayerMap.INSTANCE.putBlock(Main.SLEEPING_BAG, RenderLayer.getCutout());
 	}
 }


### PR DESCRIPTION
This PR moves all of the client-specific initialisation into the `onInitializeClient` setup method, which fixes the server crashing on startup.

Changes:
* Initialise sound system on client startup (as sounds don't exist on the server other than the server being able to instruct the client to play a sound, which doesn't seem to be being done? please correct me if i'm wrong!)
* Register sleeping bag map colours only on the client-side (as they aren't needed on the server)
* Move EntityRenderer initialisation into `onInitializeClient`. This is needed because while `@Environment(EnvType.CLIENT)` removes the field from the server, it doesn't remove the initialisation part of the statement – so that needs to be moved too.

---

Fixes #14 